### PR TITLE
[eslint config] [deps] [breaking] update `eslint-plugin-react`

### DIFF
--- a/packages/eslint-config-airbnb/package.json
+++ b/packages/eslint-config-airbnb/package.json
@@ -56,7 +56,7 @@
     "eslint-find-rules": "^1.14.3",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^5.0.0",
-    "eslint-plugin-react": "^6.10.3",
+    "eslint-plugin-react": "^7.0.0",
     "in-publish": "^2.0.0",
     "react": ">= 0.13.0",
     "safe-publish-latest": "^1.1.1",
@@ -66,7 +66,7 @@
     "eslint": "^3.19.0",
     "eslint-plugin-jsx-a11y": "^5.0.0",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-react": "^6.10.3"
+    "eslint-plugin-react": "^7.0.0"
   },
   "engines": {
     "node": ">= 4"

--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -119,6 +119,7 @@ module.exports = {
       shorthandFirst: false,
       shorthandLast: false,
       noSortAlphabetically: false,
+      reservedFirst: true,
     }],
 
     // Prevent React to be incorrectly marked as unused
@@ -139,11 +140,15 @@ module.exports = {
 
     // Prevent usage of setState in componentDidMount
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-mount-set-state.md
-    'react/no-did-mount-set-state': ['error'],
+    'react/no-did-mount-set-state': 'error',
 
     // Prevent usage of setState in componentDidUpdate
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
-    'react/no-did-update-set-state': ['error'],
+    'react/no-did-update-set-state': 'error',
+
+    // Prevent usage of setState in componentWillUpdate
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md
+    'react/no-will-update-set-state': 'error',
 
     // Prevent direct mutation of this.state
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
@@ -185,11 +190,6 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
     'react/react-in-jsx-scope': 'error',
 
-    // Restrict file extensions that may be required
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-extension.md
-    // deprecated in favor of import/extensions
-    'react/require-extension': ['off', { extensions: ['.jsx', '.js'] }],
-
     // Require render() methods to return something
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
     'react/require-render-return': 'error',
@@ -197,10 +197,6 @@ module.exports = {
     // Prevent extra closing tags for components without children
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     'react/self-closing-comp': 'error',
-
-    // Enforce spaces before the closing bracket of self-closing JSX elements
-    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
-    'react/jsx-space-before-closing': ['error', 'always'],
 
     // Enforce component methods order
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
@@ -221,13 +217,13 @@ module.exports = {
     'react/jsx-wrap-multilines': ['error', {
       declaration: true,
       assignment: true,
-      return: true
+      return: true,
+      arrow: true,
     }],
-    'react/wrap-multilines': 'off', // deprecated version
 
     // Require that the first prop in a JSX element be on a new line when the element is multiline
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
-    'react/jsx-first-prop-new-line': ['error', 'multiline'],
+    'react/jsx-first-prop-new-line': ['error', 'multiline-multiprop'],
 
     // Enforce spacing around jsx equals signs
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md
@@ -248,7 +244,6 @@ module.exports = {
     // prevent accidental JS comments from being injected into JSX as text
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md
     'react/jsx-no-comment-textnodes': 'error',
-    'react/no-comment-textnodes': 'off', // deprecated version
 
     // disallow using React.render/ReactDOM.render's return value
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md
@@ -301,6 +296,11 @@ module.exports = {
       beforeSelfClosing: 'always',
       afterOpening: 'never'
     }],
+
+    // Enforce spaces before the closing bracket of self-closing JSX elements
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-space-before-closing.md
+    // Deprecated in favor of jsx-tag-spacing
+    'react/jsx-space-before-closing': ['off', 'always'],
 
     // Prevent usage of Array index in keys
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-array-index-key.md


### PR DESCRIPTION
 - enable `react/no-will-update-set-state`
 - delete removed rules
 - `jsx-wrap-multilines`: enable `arrow` option
 - `jsx-first-prop-new-line`: change to `multiline-multiprop`
 - disable `jsx-space-before-closing` in favor of `jsx-tag-spacing`