### PR TITLE
Before submitting a PR read  contributing

### DIFF
--- a/packages/eslint-config-airbnb/rules/react.js
+++ b/packages/eslint-config-airbnb/rules/react.js
@@ -194,7 +194,7 @@ module.exports = {
 
     // Prevent multiple component definition per file
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-multi-comp.md
-    'react/no-multi-comp': ['error', { ignoreStateless: true }],
+    'react/no-multi-comp': 'off',
 
     // Prevent usage of setState
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-set-state.md


### PR DESCRIPTION
Splitting up a component into multiple components can be useful for many reasons, including making important performance optimizations.

This lint rule discourages splitting up components because it forces you to: create a new file, copy over all the relevant imports, move over any local functions/values (or move them into yet another shared module), export the component (which makes your split off component now a public export), and re-import it into the new module.

Having multiple components per file shouldn't be much different from having multiple functions per file. And you shouldn't be forced to make a component a public export if it's really just an internal implementation detail of another component.

There's an argument to be made about _exporting_ multiple components, but mostly just in the context of React.lazy because it can only import default exports and you don't want something else in that file being statically imported (because that will prevent it from being code-split).